### PR TITLE
moved from SREM to SMOVE in smove command

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -172,7 +172,7 @@
       (get-response))
 
     (define/public (smove srckey destkey member)
-      (apply-cmd "SREM" (list srckey destkey member))
+      (apply-cmd "SMOVE" (list srckey destkey member))
       (get-response))
 
     (define/public (scard key)


### PR DESCRIPTION
There was a typo in the `smove` function that would actually send `SREM` to the server.

This PR fixes that.

Cheers
